### PR TITLE
initial django-guardian integration on tileset endpoint

### DIFF
--- a/djmp/admin.py
+++ b/djmp/admin.py
@@ -1,8 +1,9 @@
 from django.contrib import admin
+from guardian.admin import GuardedModelAdmin
 
 from .models import Tileset
 
-class TilesetAdmin(admin.ModelAdmin):
+class TilesetAdmin(GuardedModelAdmin):
     readonly_fields = ('size', 'layer_uuid',)
     list_display = ('name', 'layer_name', 'server_url', 'created_by', 'created_at')
     search_fields = ['name']

--- a/djmp/fixtures/test_data.json
+++ b/djmp/fixtures/test_data.json
@@ -19,7 +19,7 @@
 },
 {
     "fields": {
-        "server_password": "geoserver",
+        "server_password": "",
         "bbox_y0": "-5.5187329999999",
         "bbox_x1": "97.10970532",
         "source_type": "wms",
@@ -28,15 +28,15 @@
         "size": "0",
         "created_at": "2016-06-21T07:45:04.193Z",
         "cache_type": "file",
-        "server_url": "http://demo.geonode.org/geoserver/wms",
+        "server_url": "http://demo.boundlessgeo.com/geoserver/wms",
         "created_by": "admin",
         "filename": "",
         "layer_zoom_start": 6,
         "bbox_x0": "96.956",
         "table_name": "",
-        "layer_name": "geonode:test_grid",
+        "layer_name": "topp:states",
         "directory": "cache/layers",
-        "server_username": "admin",
+        "server_username": "",
         "directory_layout": "tms",
         "layer_zoom_stop": 14
     },

--- a/djmp/middleware.py
+++ b/djmp/middleware.py
@@ -1,0 +1,7 @@
+from guardian.utils import get_anonymous_user
+
+
+class GuardianAuthenticationMiddleware(object):
+    def process_request(self, request):
+        if request.user.is_anonymous():
+            request.user = get_anonymous_user()

--- a/djmp/models.py
+++ b/djmp/models.py
@@ -4,8 +4,9 @@ from pyproj import Proj, transform
 
 from django.db import models
 from django.core.validators import MaxValueValidator, MinValueValidator
+from guardian.shortcuts import assign_perm
 from mapproxy.seed.config import SeedConfigurationError, ConfigurationError
-
+ 
 from .settings import FILE_CACHE_DIRECTORY
 
 log = logging.getLogger('djmapproxy')
@@ -29,7 +30,6 @@ SOURCE_TYPES = [
 ]
 
 class Tileset(models.Model):
-
     # base
     name = models.CharField(max_length=255)
     created_by = models.CharField(max_length=256)
@@ -133,4 +133,16 @@ class Tileset(models.Model):
     def bbox(self):
         return [self.bbox_x0, self.bbox_y0, self.bbox_x1, self.bbox_y1]
 
+    def add_read_perm(self, user_or_group):
+        return assign_perm('view_tileset', user_or_group, self)
 
+    def set_up_permissions(self, user_or_group=None):
+        # TODO(mvv): handle default anonymous permissions
+
+        if user_or_group:
+            self.add_read_perm(user_or_group)
+
+    class Meta:
+        permissions = (
+            ('view_tileset', 'View Tileset'),
+        )

--- a/djmp/settings.py
+++ b/djmp/settings.py
@@ -28,6 +28,12 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'djmp',
+    'guardian'
+)
+
+AUTHENTICATION_BACKENDS = (
+    'django.contrib.auth.backends.ModelBackend', # default
+    'guardian.backends.ObjectPermissionBackend',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -37,6 +43,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'djmp.middleware.GuardianAuthenticationMiddleware',
 )
 
 ROOT_URLCONF = 'djmp.urls'

--- a/djmp/tests.py
+++ b/djmp/tests.py
@@ -1,22 +1,92 @@
 from django.test import TestCase
 from django.test.client import Client
 from django.core.urlresolvers import reverse
+from django.contrib.auth.models import User
+from guardian.management import create_anonymous_user
+from guardian.shortcuts import remove_perm
 
 from .views import tileset_status, seed
 from .models import Tileset
 
 
-class DjmpTest(TestCase):
+class DjmpTestBase(TestCase):
 
     fixtures = ['test_data.json']
 
     def setUp(self):
+        super(DjmpTestBase, self).setUp()
+        create_anonymous_user(None)
+
         self.user = 'admin'
         self.passwd = 'admin'
         self.client = Client()
 
+
+class DjmpTest(DjmpTestBase):
     def test_seeding(self):
         """ test seeding"""
         self.client.login(username='admin', password='admin')
         resp = self.client.get(reverse('tileset_seed', args=(1,)))
         self.assertEqual('{"status": "started"}', resp.content)
+
+
+class TilesetTestBase(DjmpTestBase):
+    def setUp(self):
+        super(TilesetTestBase, self).setUp()
+        self.headers = {
+            # TODO(mvv): these headers are specific to mvv's local env, that 
+            #            may be bad long term
+            'X-Script-Name': '/1/map/tms/1.0.0/test/EPSG3857/1/0/0.png',
+            'HTTP_HOST': 'localhost:8000',
+            'SERVER_NAME': 'michaels-macbook-pro-2.local',
+            'X-Forwarded-Host': 'localhost:8000'
+        }
+        # seed tile
+        resp = self.client.get(reverse('tileset_seed', args=(1,)))
+
+
+class TilesetAuthTest(TilesetTestBase):
+    def setUp(self):
+        super(TilesetAuthTest, self).setUp()
+        self.testuser = User.objects.create_user(
+            'testuser',
+            'testuser@mvavnveen.net',
+            'testuser'
+        )
+        self.testuser.save()
+
+        self.uri = reverse(
+            'tileset_mapproxy',
+            args=(1, u'/tms/1.0.0/streams/EPSG3857/1/0/0.png')
+        )
+
+    def test_not_authorized_anonymous(self):
+        res = self.client.get(self.uri, **self.headers)
+        self.assertEqual(res.status_code, 403)
+
+    def test_authorized_admin(self):
+        self.client.login(username='admin', password='admin')
+        res = self.client.get(self.uri, **self.headers)
+        self.assertEqual(res.status_code, 200)
+
+    def test_not_authorized_remove_perm(self):
+        self.client.login(username='testuser', password='testuser')
+        res = self.client.get(self.uri, **self.headers)
+        self.assertEqual(res.status_code, 403)
+
+    def test_authorized_test_user_make_perm(self):
+        self.client.login(username='testuser', password='testuser')
+        res = self.client.get(self.uri, **self.headers)
+        self.assertEqual(res.status_code, 403)
+
+        tileset = Tileset.objects.get(pk=1)
+        tileset.add_read_perm(self.testuser)
+
+        self.client.login(username='testuser', password='testuser')
+        res = self.client.get(self.uri, **self.headers)
+        self.assertEqual(res.status_code, 200)
+
+        remove_perm('view_tileset', self.testuser, tileset)
+        self.client.login(username='testuser', password='testuser')
+        res = self.client.get(self.uri, **self.headers)
+        self.assertEqual(res.status_code, 403)

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setup(
         'psutil>=3.0.1',
         'pyproj==1.9.5.1',
         'webtest==2.0.20',
+        'django-guardian==1.4.4',
     ]
 )


### PR DESCRIPTION
This is a first-pass at a django guardian integration for object-level permissions.
## Changelog
- [X] view tileset now uses django-guardian permissions
  - `view_tileset` permission is added onto Tileset
  - `tileset_mapproxy` checks permissions and will return `403 Forbidden` if user does not have permissions
- [X] added tests for permissions
  - anonymous user does not have access to tileset
  - logged in user does not have access to tileset by default
  - logged in user can access tileset once permissions are added
  - admin user can access permissions
- [X] admin UI includes permissions now
  - users can be added/removed to groups and permissions can be added/removed to user
- fixture data does not use the geonode server but instead one that is more likely to be used
### Outstanding
- [ ] permissions for Tilesets are _not_ set up automatically yet
  - no signal handling for adding permissions for a new tileset, for ex.
  - _note_: @mvanveen would like some more guidance on what default permissions should be and can promptly integrate
- [ ]   no generalized decorator/middleware pattern for authorization yet
  - currently only on the `tileset_mapproxy` view
## Notes
- anonymous user currently does _not_ have view permissions by default
- would love to learn more requirements around future LDAP integration
  - might segue nicely into adding default permissions
- mvv experienced a lot of uneccessary yak shaving with django-guardian.  Considering scrapping in favor of a simpler permission model or something that matches GeoNode more closely.
  - django `AnonymousUser` vs. guardian anon user  in db required extra/unneccessary middleware
  - mvv is not sure what guardian buys us on top of standard django permissions atm
- postgres row-level auth sounds intruiging but mvv notes that current project is set up to work with e.g. sqlite.  Fixing db engine may be an unnecessary integration headache but would buy us a robust RDBMS for this project.
