### PR TITLE
Update settings.py

### DIFF
--- a/djmp/settings.py
+++ b/djmp/settings.py
@@ -6,7 +6,7 @@ from django.conf import settings
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 
 # Enable/disable global object-level permissions for app
-ENABLE_GUARDIAN_PERMISSIONS = True
+ENABLE_GUARDIAN_PERMISSIONS = False
 
 
 # SECURITY WARNING: keep the secret key used in production secret!

--- a/djmp/tests.py
+++ b/djmp/tests.py
@@ -59,6 +59,7 @@ class TilesetTestBase(DjmpTestBase):
         self.testuser.save()
 
 
+@override_settings(ENABLE_GUARDIAN_PERMISSIONS=True)
 class TilesetAuthTest(TilesetTestBase):
     def setUp(self):
         super(TilesetAuthTest, self).setUp()


### PR DESCRIPTION
Based on feedback from @jj0hns0n's "Geonode Live Issue from Sri Lanka Training" bug list it seems like we'd like guardian permissions off by default.
